### PR TITLE
Remove HT fallback functionality to simplify implementation and design

### DIFF
--- a/examples/terminal_backend_demo.rs
+++ b/examples/terminal_backend_demo.rs
@@ -73,8 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("=== Demo 2: Direct Backend ===");
     let direct_config = TerminalBackendConfig::new()
         .with_backend_type(BackendType::Direct)
-        .with_direct_timeout(Duration::from_secs(10))
-        .with_fallback(false);
+        .with_direct_timeout(Duration::from_secs(10));
 
     match TerminalBackendManager::new(direct_config).await {
         Ok(direct_manager) => {
@@ -123,19 +122,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Demo 3: Try HT backend with fallback
-    info!("=== Demo 3: HT Backend with Fallback ===");
-    let ht_config = TerminalBackendConfig::new()
-        .with_backend_type(BackendType::Ht)
-        .with_fallback(true); // Enable fallback to direct
+    // Demo 3: Try HT backend
+    info!("=== Demo 3: HT Backend ===");
+    let ht_config = TerminalBackendConfig::new().with_backend_type(BackendType::Ht);
 
     match TerminalBackendManager::new(ht_config).await {
         Ok(ht_manager) => {
-            info!("Created HT backend (or fallback) successfully");
-            info!(
-                "Actual backend type: {}",
-                ht_manager.backend().backend_type()
-            );
+            info!("Created HT backend successfully");
+            info!("Backend type: {}", ht_manager.backend().backend_type());
 
             // Test basic command execution
             match ht_manager.backend().execute_command("date").await {
@@ -149,7 +143,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         Err(e) => {
-            error!("Failed to create HT backend: {}", e);
+            info!("HT backend not available: {}", e);
         }
     }
 

--- a/src/terminal_backend/config.rs
+++ b/src/terminal_backend/config.rs
@@ -8,7 +8,6 @@ pub struct TerminalBackendConfig {
     pub backend_type: BackendType,
     pub ht_config: HtBackendConfig,
     pub direct_config: DirectBackendConfig,
-    pub fallback_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,7 +30,6 @@ impl Default for TerminalBackendConfig {
             backend_type: BackendType::Direct,
             ht_config: HtBackendConfig::default(),
             direct_config: DirectBackendConfig::default(),
-            fallback_enabled: true,
         }
     }
 }
@@ -86,11 +84,6 @@ impl TerminalBackendConfig {
         self
     }
 
-    pub fn with_fallback(mut self, enabled: bool) -> Self {
-        self.fallback_enabled = enabled;
-        self
-    }
-
     pub fn validate(&self) -> Result<(), TerminalBackendError> {
         match self.backend_type {
             BackendType::Ht => {
@@ -124,11 +117,6 @@ impl TerminalBackendConfig {
         // Read shell from environment
         if let Ok(shell) = std::env::var("TERMINAL_SHELL") {
             config.direct_config.shell = Some(shell);
-        }
-
-        // Read fallback setting from environment
-        if let Ok(fallback_str) = std::env::var("TERMINAL_BACKEND_FALLBACK") {
-            config.fallback_enabled = fallback_str.parse().unwrap_or(true);
         }
 
         Ok(config)


### PR DESCRIPTION
Closes #28

## Summary
Remove the HT fallback functionality that automatically falls back to direct backend when HT is unavailable. This simplifies the implementation and design by removing unnecessary complexity.

## Changes Made
✅ **Configuration (config.rs)**
- Removed `fallback_enabled` field from `TerminalBackendConfig`
- Removed `with_fallback()` method
- Removed `TERMINAL_BACKEND_FALLBACK` environment variable support
- Updated `Default` implementation

✅ **Factory (factory.rs)**
- Simplified `create_ht_backend()` method signature
- Removed fallback logic in HT backend creation
- Removed `create_ht_or_fallback()` factory method
- Always return errors on HT backend failure instead of falling back
- Cleaned up unused imports

✅ **Examples (terminal_backend_demo.rs)**
- Removed `.with_fallback()` calls
- Updated demo descriptions to reflect new behavior
- Changed error handling to log info instead of error for HT unavailability

✅ **Testing**
- All existing tests pass
- No fallback-specific tests needed removal
- Code formatting and linting clean

## Breaking Changes
This is a breaking change that affects:
- Code that explicitly enables/disables fallback via `with_fallback()`
- Configuration that uses `TERMINAL_BACKEND_FALLBACK` environment variable
- Users who depend on automatic fallback to direct backend

**Migration**: Users who want direct backend should explicitly configure `BackendType::Direct` instead of relying on fallback behavior.

## Benefits
- **Simplified design**: Clearer separation between HT and direct backends
- **Reduced complexity**: Less branching logic and fewer edge cases
- **Better error handling**: Explicit failures instead of silent fallbacks
- **Clearer user expectations**: Users know exactly which backend they're using

## Test Results
- ✅ All 39 tests passing
- ✅ Cargo fmt/clippy clean
- ✅ CI build and test passing

🤖 Generated with [Claude Code](https://claude.ai/code)