### PR TITLE
Implement PTY output monitoring and remove test command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "rule-agents"
+name = "ccauto"
 version = "0.1.0"
 edition = "2021"
 authors = ["sonesuke <iamsonesuke@gmail.com>"]
 description = "YAML-driven agent auto-control system (command-line tool)"
 license = "MIT"
-repository = "https://github.com/sonesuke/rule-agents"
+repository = "https://github.com/sonesuke/ccauto"
 
 [[bin]]
-name = "rule-agents"
+name = "ccauto"
 path = "src/main.rs"
 
 [dependencies]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -93,23 +93,11 @@ impl Agent {
 
     pub async fn send_keys(&self, keys: &str) -> Result<()> {
         // AGENT SEND_KEYS DEBUG
-        crate::debug_print!("🔄 Agent::send_keys called with: {:?}", keys);
+        tracing::debug!("🔄 Agent::send_keys called with: {:?}", keys);
 
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("pty_debug.log")
-        {
-            use std::io::Write;
-            let timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-            let _ = writeln!(file, "[{}] === AGENT SEND_KEYS ===", timestamp);
-            let _ = writeln!(file, "Keys: {:?}", keys);
-            let _ = writeln!(file, "About to call ht_process.send_input");
-            let _ = writeln!(file, "---");
-        }
+        tracing::debug!("=== AGENT SEND_KEYS ===");
+        tracing::debug!("Keys: {:?}", keys);
+        tracing::debug!("About to call ht_process.send_input");
 
         self.ht_process
             .send_input(keys.to_string())

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -20,8 +20,6 @@ pub struct Cli {
 pub enum Commands {
     /// Load and display rules
     Show(ShowArgs),
-    /// Test rule matching against capture text
-    Test(TestArgs),
 }
 
 #[derive(Args, Debug)]
@@ -29,14 +27,4 @@ pub struct ShowArgs {
     /// Path to config YAML file
     #[arg(long, default_value = "config.yaml")]
     pub config: PathBuf,
-}
-
-#[derive(Args, Debug)]
-pub struct TestArgs {
-    /// Path to config YAML file
-    #[arg(long, default_value = "config.yaml")]
-    pub config: PathBuf,
-    /// Capture text to test against rules
-    #[arg(short, long)]
-    pub capture: String,
 }

--- a/src/ruler/decision.rs
+++ b/src/ruler/decision.rs
@@ -1,8 +1,6 @@
 use crate::ruler::rule::CompiledRule;
 use crate::ruler::rule::{resolve_capture_groups, resolve_capture_groups_in_vec};
 use crate::ruler::types::ActionType;
-use std::fs::OpenOptions;
-use std::io::Write;
 
 /// Matches capture text against compiled rules and returns the appropriate action.
 ///
@@ -27,20 +25,10 @@ pub fn decide_action(capture: &str, rules: &[CompiledRule]) -> ActionType {
     }
 
     // Log to file for debugging
-    if let Ok(mut file) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("pattern_match_debug.log")
-    {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let _ = writeln!(file, "[{}] CHECKING: {:?}", timestamp, capture);
-        let _ = writeln!(file, "  Clean content: {}", capture.trim());
-        let _ = writeln!(file, "  Length: {}", capture.len());
-        let _ = writeln!(file, "  Rules to check: {}", rules.len());
-    }
+    tracing::debug!("CHECKING: {:?}", capture);
+    tracing::debug!("  Clean content: {}", capture.trim());
+    tracing::debug!("  Length: {}", capture.len());
+    tracing::debug!("  Rules to check: {}", rules.len());
 
     for (i, rule) in rules.iter().enumerate() {
         if let Some(captures) = rule.regex.captures(capture) {
@@ -51,26 +39,15 @@ pub fn decide_action(capture: &str, rules: &[CompiledRule]) -> ActionType {
                 capture
             );
 
-            // Log to file
-            if let Ok(mut file) = OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open("pattern_match_debug.log")
-            {
-                let _ = writeln!(
-                    file,
-                    "  ✅ MATCHED! Rule #{} Pattern: {:?}",
-                    i,
-                    rule.regex.as_str()
-                );
-                let _ = writeln!(file, "     Action: {:?}", rule.action);
-                let _ = writeln!(
-                    file,
-                    "     Full match: {:?}",
-                    captures.get(0).map(|m| m.as_str())
-                );
-                let _ = writeln!(file, "---");
-            }
+            // Log matched rule details
+            tracing::debug!(
+                "  ✅ MATCHED! Rule #{} Pattern: {:?}",
+                i,
+                rule.regex.as_str()
+            );
+            tracing::debug!("     Action: {:?}", rule.action);
+            tracing::debug!("     Full match: {:?}", captures.get(0).map(|m| m.as_str()));
+            tracing::debug!("---");
 
             // Extract capture groups
             let captured_groups: Vec<String> = captures

--- a/src/web_server/server.rs
+++ b/src/web_server/server.rs
@@ -114,7 +114,7 @@ async fn websocket_handler(
     State((agent, _)): State<(Arc<Agent>, AssetCache)>,
 ) -> Response {
     info!("🔌 WebSocket upgrade request received");
-    crate::debug_print!("🔌 WebSocket connection attempt");
+    tracing::debug!("🔌 WebSocket connection attempt");
     ws.on_upgrade(move |socket| handle_websocket(socket, agent))
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,10 +1,8 @@
-// Integration tests for rule-agents binary
+// Integration tests for ccauto binary
 // Since this is now a binary-only project, these tests verify the binary functionality
 // through command line interface testing
 
-use std::io::Write;
 use std::process::Command;
-use tempfile::NamedTempFile;
 
 #[test]
 fn test_binary_help_command() {
@@ -15,7 +13,7 @@ fn test_binary_help_command() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("rule-agents"));
+    assert!(stdout.contains("ccauto"));
     assert!(stdout.contains("YAML-driven agent auto-control system"));
 }
 
@@ -32,26 +30,7 @@ fn test_binary_show_command() {
     assert!(stdout.contains("rules"));
 }
 
-#[test]
-fn test_binary_test_command() {
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--",
-            "test",
-            "--config",
-            "config.yaml",
-            "--capture",
-            "Do you want to proceed",
-        ])
-        .output()
-        .expect("Failed to execute command");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Input:"));
-    assert!(stdout.contains("Result:"));
-}
+// Test command has been removed - this test is no longer applicable
 
 #[test]
 fn test_binary_with_invalid_rules_file() {
@@ -66,37 +45,7 @@ fn test_binary_with_invalid_rules_file() {
     assert!(stderr.contains("Error:") || stderr.contains("Failed"));
 }
 
-#[test]
-fn test_binary_with_custom_rules() {
-    let yaml_content = r#"
-rules:
-  - priority: 10
-    pattern: "test pattern"
-    action: "send_keys"
-    keys: ["test", "\r"]
-"#;
-
-    let mut temp_file = NamedTempFile::new().unwrap();
-    write!(temp_file, "{}", yaml_content).unwrap();
-
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--",
-            "test",
-            "--config",
-            temp_file.path().to_str().unwrap(),
-            "--capture",
-            "test pattern",
-        ])
-        .output()
-        .expect("Failed to execute command");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Input:"));
-    assert!(stdout.contains("test pattern"));
-}
+// Test command has been removed - this test is no longer applicable
 
 #[test]
 fn test_binary_version() {
@@ -107,5 +56,5 @@ fn test_binary_version() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("rule-agents"));
+    assert!(stdout.contains("ccauto"));
 }


### PR DESCRIPTION
## Summary
- Add dedicated PTY output monitoring with `process_pty_output` function
- Remove test command and related code (`TestArgs`, `handle_test_command`)  
- Split `process_direct_output` to handle only stdout/stderr
- Add `Arc<Ruler>` for sharing between async PTY monitoring tasks
- Enable real-time pattern matching on terminal output
- Update binary name from rule-agents to ccauto
- Fix integration tests for removed test command

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass  
- [x] Successfully tested with `examples/basic/config.yaml`
- [x] Successfully tested with `examples/claude/config.yaml`
- [x] Code quality checks pass (cargo fmt + clippy)

🤖 Generated with [Claude Code](https://claude.ai/code)