### PR TITLE
Clean up redundant logging and update documentation

### DIFF
--- a/src/agent/pty_process.rs
+++ b/src/agent/pty_process.rs
@@ -196,12 +196,9 @@ impl PtyProcess {
                 tracing::debug!("🚀 Command monitor task started");
                 if let Err(e) = Self::monitor_command_process(command_clone, tx_clone).await {
                     error!("Command monitoring failed: {}", e);
-                    println!("❌ Command monitoring failed: {}", e);
                 }
             });
         } else {
-            println!("❌ Command monitoring channel not available");
-
             tracing::debug!("❌ Channel NOT available");
         }
 
@@ -259,8 +256,11 @@ impl PtyProcess {
         tracing::debug!("Parsed args: {:?}", args);
 
         if args.is_empty() {
-            println!("❌ Invalid command for monitoring: {:?}", command);
-            tracing::debug!("❌ Invalid command: args={:?}", args);
+            tracing::debug!(
+                "❌ Invalid command for monitoring: {:?}, args={:?}",
+                command,
+                args
+            );
             return Ok(());
         }
 
@@ -293,8 +293,7 @@ impl PtyProcess {
                 child
             }
             Err(e) => {
-                println!("❌ Failed to spawn process {}: {}", command_name, e);
-                tracing::debug!("❌ Failed to spawn {}: {}", command_name, e);
+                error!("Failed to spawn process {}: {}", command_name, e);
                 return Err(PtyProcessError::IoError(e));
             }
         };
@@ -316,7 +315,7 @@ impl PtyProcess {
                             is_stdout: true,
                         };
                         if let Err(e) = tx_stdout.send(output) {
-                            println!("❌ Failed to send stdout: {}", e);
+                            error!("Failed to send stdout: {}", e);
                             break;
                         } else {
                             tracing::debug!("✅ Sent stdout to channel: {:?}", line);
@@ -326,7 +325,7 @@ impl PtyProcess {
                 tracing::debug!("📡 Stdout monitoring ended for {}", command_name_clone);
             });
         } else {
-            println!("❌ No stdout pipe available");
+            error!("No stdout pipe available");
         }
 
         // Capture stderr
@@ -346,7 +345,7 @@ impl PtyProcess {
                             is_stdout: false,
                         };
                         if let Err(e) = tx_stderr.send(output) {
-                            println!("❌ Failed to send stderr: {}", e);
+                            error!("Failed to send stderr: {}", e);
                             break;
                         } else {
                             tracing::debug!("✅ Sent stderr to channel: {:?}", line);
@@ -356,7 +355,7 @@ impl PtyProcess {
                 tracing::debug!("📡 Stderr monitoring ended for {}", command_name_clone);
             });
         } else {
-            println!("❌ No stderr pipe available");
+            error!("No stderr pipe available");
         }
 
         // Wait for process to complete

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,9 +27,9 @@ async fn main() -> Result<()> {
 
     // Initialize logging based on debug flag
     let level = if cli.debug {
-        tracing::Level::DEBUG // --debug時はDEBUGレベル以上
+        tracing::Level::DEBUG // DEBUG level or higher when --debug
     } else {
-        tracing::Level::WARN // 通常時はWARNレベル以上（エラーと警告のみ）
+        tracing::Level::WARN // WARN level or higher in normal operation (errors and warnings only)
     };
     tracing_subscriber::fmt().with_max_level(level).init();
 


### PR DESCRIPTION
## Summary
- Removed redundant `println\!` statements where logging macros (`error\!`, `info\!`, etc.) are already used
- Replaced Japanese comments with English translations in `src/main.rs`
- Completely rewrote README.md to reflect current architecture

## Changes Made

### Logging Cleanup
- Removed 8 redundant `println\!` statements from `src/agent/pty_process.rs`
- Changed some `println\!` to appropriate log levels (`error\!`) where needed
- Kept the logging macros for proper log level control

### Documentation Updates
- Removed outdated HT (Headless Terminal) references - ccauto now uses its own PTY implementation
- Added Claude command monitoring documentation
- Fixed binary name references (now `ccauto` instead of `./target/release/ccauto`)
- Added reference to CLAUDE.md for development guidelines
- Updated examples to reflect current functionality

### Japanese Comment Translation
- `--debug時はDEBUGレベル以上` → `DEBUG level or higher when --debug`
- `通常時はWARNレベル以上（エラーと警告のみ）` → `WARN level or higher in normal operation (errors and warnings only)`

## Test Plan
- [x] `cargo test` - All tests pass
- [x] `cargo clippy -- -D warnings` - No warnings
- [x] `cargo fmt -- --check` - Code properly formatted
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)