### PR TITLE
Fix rules evaluation to only work when agent is active and fix diff_timeout to reset on any terminal output

### DIFF
--- a/examples/diff-timeout-demo/README.md
+++ b/examples/diff-timeout-demo/README.md
@@ -4,7 +4,7 @@ This example demonstrates the new `diff_timeout` rule type that triggers actions
 
 ## How It Works
 
-The `diff_timeout` rule type monitors the time since the last successful pattern match and triggers specified actions when timeout periods are reached. This is useful for:
+The `diff_timeout` rule type monitors the time since ANY terminal output was received and triggers specified actions when timeout periods are reached. The timeout counter resets whenever any terminal output is received, not just when patterns match. This is useful for:
 
 - Detecting when monitoring has gone quiet
 - Implementing watchdog behavior
@@ -79,7 +79,9 @@ The timeout functionality is implemented through:
 
 1. **Rule Compilation:** `diff_timeout` field is parsed into `Duration` objects
 2. **State Tracking:** `TimeoutState` tracks last activity time and timer states  
-3. **Decision Engine:** Enhanced to handle both pattern matching and timeout checks
-4. **Monitoring Loop:** Periodically checks timeout conditions every 50ms
+3. **Activity Reset:** Timeout counters reset on ANY terminal output, not just pattern matches
+4. **Agent Status:** Rules are only evaluated when agents are in Active status
+5. **Decision Engine:** Enhanced to handle both pattern matching and timeout checks
+6. **Monitoring Loop:** Periodically checks timeout conditions every 50ms
 
-This provides efficient, responsive timeout detection without impacting normal pattern matching performance.
+This provides efficient, responsive timeout detection without impacting normal pattern matching performance. The timeout can trigger multiple times during a session as it resets whenever new terminal output is received.

--- a/src/cli/helpers.rs
+++ b/src/cli/helpers.rs
@@ -330,6 +330,10 @@ pub async fn process_pty_output(
     ruler: &ruler::Ruler,
     queue_manager: &SharedQueueManager,
 ) -> Result<()> {
+    // Reset timeout activity for diff_timeout rules whenever ANY terminal output is received
+    // This ensures diff_timeout detects "no terminal output" rather than "no pattern matches"
+    ruler.reset_timeout_activity().await;
+
     // Remove ANSI escape sequences for cleaner pattern matching
     let clean_output = strip_ansi_escapes(pty_output);
 


### PR DESCRIPTION
Closes #104

## Summary
Fixes two critical issues with rules evaluation:

### 1. Rules Evaluation Timing
**Problem**: Rules were being evaluated for both Active and Idle agents
**Solution**: Added agent status checks to only process rules when agent is Active

### 2. diff_timeout Reset Behavior  
**Problem**: diff_timeout only reset on pattern matches, not terminal output
**Solution**: Added reset_timeout_activity() method called on ANY terminal output

## Implementation Details

### Changes Made:
- **main.rs**: Added agent status checks before processing rules and timeout rules
- **ruler/mod.rs**: Added reset_timeout_activity() method to Ruler
- **cli/helpers.rs**: Call reset_timeout_activity() whenever PTY output is received  
- **ruler/decision.rs**: Added test helper method and comprehensive tests
- **examples/diff-timeout-demo/README.md**: Updated documentation

### Key Features:
- ✅ Rules only evaluate when agent status is Active
- ✅ diff_timeout resets on ANY terminal output (not just pattern matches)
- ✅ diff_timeout can trigger multiple times in a session
- ✅ Comprehensive test coverage for new behavior
- ✅ Backward compatibility maintained

## Test Plan
- [x] Rules are only evaluated when agent status is Active
- [x] diff_timeout correctly detects periods of no terminal output  
- [x] diff_timeout can trigger multiple times in a session
- [x] diff_timeout resets on any terminal output, not just pattern matches
- [x] Existing pattern rules continue to work as before
- [x] All existing tests pass
- [x] New tests added for regression prevention

## Testing
- Added test_diff_timeout_multiple_triggers() for multiple trigger behavior
- Added test_reset_timeout_activity() for Ruler method testing
- All 33 unit tests + 4 integration tests pass
- Pre-commit hooks (cargo test, clippy, fmt) all pass